### PR TITLE
Update video_duration.py 

### DIFF
--- a/nautilus-python/extensions/video_duration.py
+++ b/nautilus-python/extensions/video_duration.py
@@ -13,21 +13,34 @@ class VideoDurationColumnExtension(GObject.GObject, Nautilus.ColumnProvider, Nau
                                 label="Duration",
                                 description="Shows the duration of video files")]
 
-    def update_file_info(self, file):
+    def update_file_info_full(self, provider, handle, closure, file):
+        duration = ''
         if file.get_mime_type().startswith("video"):
-            file_path = file.get_location().get_path()
-            try:
-                result = subprocess.run(['mediainfo', '--Inform=Video;%Duration%', file_path],
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE,
-                                        text=True)
-                duration_ms = int(result.stdout.strip())
-                duration = self.convert_millis(duration_ms)
-                file.add_string_attribute('video_duration', duration)
-            except Exception as e:
-                file.add_string_attribute('video_duration', '')
-        else:
-            file.add_string_attribute('video_duration', '')
+            GObject.timeout_add_seconds(1, self.update_duration, provider, handle, closure, file)
+            return Nautilus.OperationResult.IN_PROGRESS
+            
+        file.add_string_attribute('video_duration', duration)
+        
+        return Nautilus.OperationResult.COMPLETE
+            
+    def update_duration(self, provider, handle, closure, file):
+        file_path = file.get_location().get_path()
+        try:
+            result = subprocess.run(['mediainfo', '--Inform=Video;%Duration%', file_path],
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    text=True)
+            duration_ms = int(result.stdout.strip())
+            duration = self.convert_millis(duration_ms)
+        except Exception as e:
+            duration = ''
+            
+        file.add_string_attribute('video_duration', duration)
+        
+        Nautilus.info_provider_update_complete_invoke(closure, provider, 
+                               handle, Nautilus.OperationResult.COMPLETE)
+
+        return False
 
     def convert_millis(self, millis):
         seconds = (millis / 1000) % 60


### PR DESCRIPTION
I had some issues loading folders with large numbers of video.

Implemented the update_file_info_full function to allow processing of large files that take more time without freezing up Nautilus.
https://gnome.pages.gitlab.gnome.org/nautilus-python/class-nautilus-python-info-provider.html#method-nautilus-python-info-provider--update-file-info-full

Referenced code here: https://stackoverflow.com/questions/9660065/speed-up-nautilus-python-extensions-for-reading-images-exif